### PR TITLE
Fix hardcoded pixel ID in img src

### DIFF
--- a/dist/components/FBPixelScript.js
+++ b/dist/components/FBPixelScript.js
@@ -19,5 +19,5 @@ const FBPixelScript = () => (react_1.default.createElement(react_1.default.Fragm
         `,
         } }),
     react_1.default.createElement("noscript", null,
-        react_1.default.createElement("img", { height: "1", width: "1", alt: "FB Pixel", style: { display: 'none' }, src: "https://www.facebook.com/tr?id=1724438047628884&ev=PageView&noscript=1" }))));
+        react_1.default.createElement("img", { height: "1", width: "1", alt: "FB Pixel", style: { display: 'none' }, src: `https://www.facebook.com/tr?id=${process.env.NEXT_PUBLIC_FB_PIXEL_ID}&ev=PageView&noscript=1` }))));
 exports.default = FBPixelScript;

--- a/dist/index.js
+++ b/dist/index.js
@@ -25,7 +25,7 @@ exports.fbPageView = fbPageView;
 const fbEvent = (event) => {
     const eventId = event.eventId ? event.eventId : (0, uuid_1.v4)();
     setTimeout(() => {
-        if (event.enableStandardPixel) {
+        if (typeof window !== "undefined" && event.enableStandardPixel) {
             window.fbq('track', event.eventName, {
                 content_type: 'product',
                 contents: event.products.map((product) => ({ id: product.sku, quantity: product.quantity })),

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "lint": "eslint . --ext .js,.ts,.jsx,.tsx",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc --build"
   },
   "repository": {
     "type": "git",

--- a/src/components/FBPixelScript.jsx
+++ b/src/components/FBPixelScript.jsx
@@ -18,7 +18,7 @@ const FBPixelScript = () => (
       }}
     />
     <noscript>
-      <img height="1" width="1" alt="FB Pixel" style={{ display: 'none' }} src="https://www.facebook.com/tr?id=1724438047628884&ev=PageView&noscript=1" />
+      <img height="1" width="1" alt="FB Pixel" style={{ display: 'none' }} src={`https://www.facebook.com/tr?id=${process.env.NEXT_PUBLIC_FB_PIXEL_ID}&ev=PageView&noscript=1`} />
     </noscript>
   </>
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const fbEvent = (event: FBEventType): void => {
   const eventId = event.eventId ? event.eventId : uuidv4();
 
   setTimeout(() => {
-    if (event.enableStandardPixel) {
+    if (typeof window !== "undefined" && event.enableStandardPixel) {
       window.fbq('track', event.eventName, {
         content_type: 'product',
         contents: event.products.map((product) => (


### PR DESCRIPTION
The `id` use to get FB pixel should match that used in JS