### PR TITLE
Don't fire pixel during SSR

### DIFF
--- a/src/conversion-api.ts
+++ b/src/conversion-api.ts
@@ -28,7 +28,7 @@ const fbPageView = (): void => {
 const fbEvent = (event: FBEventType): void => {
   const eventId = event.eventId ? event.eventId : uuidv4();
 
-  if (event.enableStandardPixel) {
+  if (typeof window !== "undefined" && event.enableStandardPixel) {
     const clientSidePayload = {
       content_type: 'product',
       contents: event.products.map((product) => (

--- a/src/conversion-api.ts
+++ b/src/conversion-api.ts
@@ -28,7 +28,7 @@ const fbPageView = (): void => {
 const fbEvent = (event: FBEventType): void => {
   const eventId = event.eventId ? event.eventId : uuidv4();
 
-  if (typeof window !== "undefined" && event.enableStandardPixel) {
+  if (typeof window !== 'undefined' && event.enableStandardPixel) {
     const clientSidePayload = {
       content_type: 'product',
       contents: event.products.map((product) => (


### PR DESCRIPTION
We get this often in production build logs during SSR events
```
ReferenceError: window is not defined
    at fbEvent (/app/node_modules/@rivercode/facebook-conversion-api-nextjs/dist/conversion-api.js:29:9)
    at sendFacebookViewContentEvent (/app/.next/server/chunks/2614.js:45:89)
    ...
 ```