### PR TITLE
Add support for test event codes

### DIFF
--- a/src/conversion-api.ts
+++ b/src/conversion-api.ts
@@ -56,6 +56,7 @@ const fbEvent = (event: FBEventType): void => {
       currency: event.currency,
       userAgent: navigator.userAgent,
       sourceUrl: window.location.href,
+      testEventCode: event.testEventCode,
     });
 
     fetch('/api/fb-events', {

--- a/src/handlers/event-handler.ts
+++ b/src/handlers/event-handler.ts
@@ -35,6 +35,7 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     currency,
     userAgent,
     sourceUrl,
+    testEventCode,
   } = req.body as Arguments;
 
   if (!eventName || !products || products?.length < 1) {
@@ -56,6 +57,7 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     ipAddress: getClientIpAddress(req),
     userAgent,
     sourceUrl,
+    testEventCode,
   };
 
   const response = await sendServerSideEvent(payload);

--- a/src/handlers/event-handler.types.ts
+++ b/src/handlers/event-handler.types.ts
@@ -11,4 +11,5 @@ export type Arguments = {
   currency?: string
   userAgent: string
   sourceUrl: string
+  testEventCode?: string
 };

--- a/src/services/server-side-events/server-side-events.ts
+++ b/src/services/server-side-events/server-side-events.ts
@@ -18,6 +18,7 @@ import { sha256Hash } from '../../utils/hash';
  * @param ipAddress
  * @param userAgent
  * @param sourceUrl
+ * @param testEventCode
  * @constructor
  */
 const sendServerSideEvent = async ({
@@ -33,6 +34,7 @@ const sendServerSideEvent = async ({
   ipAddress,
   userAgent,
   sourceUrl,
+  testEventCode,
 }: Arguments): Promise<Response> => {
   const formData = new FormData();
 
@@ -66,6 +68,9 @@ const sendServerSideEvent = async ({
   }];
 
   formData.append('data', JSON.stringify(eventData));
+  if (testEventCode) {
+    formData.append('test_event_code', testEventCode);
+  }
   formData.append('access_token', process.env.FB_ACCESS_TOKEN ?? '');
 
   return graphApi({

--- a/src/services/server-side-events/server-side-events.types.ts
+++ b/src/services/server-side-events/server-side-events.types.ts
@@ -14,6 +14,7 @@ export type Arguments = {
   ipAddress: string
   userAgent: string
   sourceUrl: string
+  testEventCode?: string
 };
 
 export type Response = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,7 @@ type FBEventType = {
   value?: number
   currency?: string
   enableStandardPixel?: boolean
+  testEventCode?: string
 };
 
 export default FBEventType;


### PR DESCRIPTION
The Facebook Events Manager allows testing events by including a `test_event_code` parameter in the request with a code like `TEST123456`. These appear nearly instantly in the test tab, allowing users to quickly check if things are working. This small change allows developers to use that code.