### PR TITLE
Exports server-side event and request utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import { getClientIpAddress, getClientFbp, getClientFbc } from './utils/request'
 export {
   fbPageView,
   fbEvent,
-	getClientIpAddress,
-	getClientFbp,
-	getClientFbc,
-	sendServerSideEvent
+  getClientIpAddress,
+  getClientFbp,
+  getClientFbc,
+  sendServerSideEvent
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { fbPageView, fbEvent } from './conversion-api';
+import { sendServerSideEvent } from './services/server-side-events';
+import { getClientIpAddress, getClientFbp, getClientFbc } from './utils/request';
 
 export {
   fbPageView,
   fbEvent,
+	getClientIpAddress,
+	getClientFbp,
+	getClientFbc,
+	sendServerSideEvent
 };

--- a/src/services/server-side-events.ts
+++ b/src/services/server-side-events.ts
@@ -3,8 +3,8 @@ import graphApi from '../api/graph-api';
 import { sha256Hash } from '../utils/hash';
 
 type Arguments = {
-  eventName: string
-  eventId: string
+  eventName?: string
+  eventId?: string
   emails?: Array<string> | null
   phones?: Array<string> | null
   firstName?: string
@@ -18,9 +18,9 @@ type Arguments = {
   }[]
   value?: number
   currency?: string
-  fbp: string
-  fbc: string
-  ipAddress: string
+  fbp?: string
+  fbc?: string
+  ipAddress?: string
   userAgent: string
   sourceUrl: string
   testEventCode?: string


### PR DESCRIPTION
Allows `getClientIpAddress`, `getClientFbp`, `getClientFbc`, and `sendServerSideEvent` to be imported. This will let you call these methods directly in the backend.