### PR TITLE
fix: correct fbc format extraction from fbclid parameter

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -50,7 +50,10 @@ const getClientFbc = (req: NextApiRequest): string => {
     const url = new URL(req.headers.referer);
 
     if (url.searchParams.has('fbclid')) {
-      return url.searchParams.get('fbclid') ?? '';
+      const fbclid = url.searchParams.get('fbclid') || '';
+      const subdomainIndex = getSubdomainIndex(req.headers.host || '');
+      const creationTime = Date.now();
+      return `fb.${subdomainIndex}.${creationTime}.${fbclid}`;
     }
   }
 


### PR DESCRIPTION
The formatted ClickID value must be of the form `version.subdomainIndex.creationTime.<fbclid>`, where:

- version is always this prefix: fb

- subdomainIndex is which domain the cookie is defined on ('com' = 0, 'example.com' = 1, 'www.example.com' = 2)

- creationTime is the UNIX time since epoch in milliseconds when the _fbc was stored. If you don't save the _fbc cookie, use the timestamp when you first observed or received this fbclid value

- <fbclid> is the value for the fbclid query parameter in the page URL.

Here’s an example of what the resulting fbc parameter value could look like (note that the <fbclid> portion is invalid):

`fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890`

